### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ __pycache__/
 .Python
 build/
 develop-eggs/
-dist/
 downloads/
 eggs/
 .eggs/


### PR DESCRIPTION
The defaults you used in your `.gitignore` file stopped the `index_files/libs/revealjs/dist` folder from being comitted, which lead to you missing the quarto and revealjs css and js files that makes it look right 😄 

<img width="640" alt="Screenshot 2023-09-18 at 10 59 02 PM" src="https://github.com/isabelizimm/positconf2023-python-docs/assets/14034784/438ac6ae-0a02-4ab8-9e2f-ffe29caa7311">

So merge this in, and commit the folder and you should be good!